### PR TITLE
京东农场Cron时间转为UTC为基础

### DIFF
--- a/.github/workflows/jd_fruit.yaml
+++ b/.github/workflows/jd_fruit.yaml
@@ -6,7 +6,7 @@ name: 京东农场
 on:
     workflow_dispatch:
     schedule:
-        - cron: "5 6-18/6 * * *"
+        - cron: "5 4,8,23 * * *"
 
 jobs:
     build:


### PR DESCRIPTION
由于农场领水滴分别在6-9，11-14，17-21，所以Cron时间要根据此转换为UTC时间。
即
`
5 4,8,23 * * *
`