### PR TITLE
更改喜马拉雅执行时间

### DIFF
--- a/.github/workflows/xmly_speed.yaml
+++ b/.github/workflows/xmly_speed.yaml
@@ -3,7 +3,7 @@ name: 喜马拉雅极速定制版
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '20,50 * * * *'
   watch:
     types: [started]
 jobs:


### PR DESCRIPTION
与先前一样均为半小时执行一次，但可与绝大多数京东脚本执行时间错开。