### PR TITLE
调整京小超脚本执行时间

### DIFF
--- a/.github/workflows/jd_blueCoin.yaml
+++ b/.github/workflows/jd_blueCoin.yaml
@@ -6,7 +6,7 @@ name: 京小超领蓝币
 on:
     workflow_dispatch:
     schedule:
-        - cron: "5 16 * * *"
+        - cron: "15 16 * * *"
     watch:
         types: [started]
     repository_dispatch:

--- a/.github/workflows/jd_superMarket.yaml
+++ b/.github/workflows/jd_superMarket.yaml
@@ -6,7 +6,7 @@ name: 京小超
 on:
     workflow_dispatch:
     schedule:
-        - cron: "10 */4 * * *"
+        - cron: "5 */4 * * *"
     watch:
         types: [started]
     repository_dispatch:


### PR DESCRIPTION
京小超兑换京豆功能改到主脚本中，之前的执行顺序容易抢不到。