### PR TITLE
调整同步时间

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -2,7 +2,7 @@
 name: sync-sazs34-scripts
 on:
   schedule:
-    - cron: '1 0,15 * * *'
+    - cron: '5 0,15 * * *'
   workflow_dispatch:
   watch:
     types: started


### PR DESCRIPTION
8点时有京东脚本运行，不确定脚本会不会运行到一半，然后就被强制同步，所以往后调几分钟吧。